### PR TITLE
Improve the update of the msys2 packages

### DIFF
--- a/04_update_msys2_choco_admin.cmd
+++ b/04_update_msys2_choco_admin.cmd
@@ -1,3 +1,4 @@
 @echo off
-::update chocolatey and msys2
-choco upgrade chocolatey msys2 -y
+::upgrade chocolatey and msys2 and trigger the update of the msys2 packages
+choco upgrade chocolatey -y
+choco upgrade msys2 -f -y


### PR DESCRIPTION
The msys2 choco package is updated upstream only after a new release of the
msys2 installer. Forcing the msys2 choco package upgrade triggers the update of
the msys2 packages with the automatic shell restarts done by the choco package.