### PR TITLE
Drop msys2 system update in sh script

### DIFF
--- a/02_install_worker.sh
+++ b/02_install_worker.sh
@@ -24,9 +24,6 @@ echo "Write the number of cores to be contributed to fishtest:"
 echo "(max suggested 'Total CPU cores - 1')"
 read n_cores
 
-# update msys2 packages
-pacman -Syuu --noconfirm
-
 # install packages if not already installed
 pacman -S --noconfirm --needed unzip make mingw-w64-x86_64-gcc mingw-w64-x86_64-python3
 


### PR DESCRIPTION
The msys2 system update could require some shell restarts blocking the script.
Better to update msys2 system with "04_update_msys2_choco_admin.cmd".